### PR TITLE
don't call next until the current line has been successfully flushed

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,13 +57,11 @@ LogStream.prototype._write = function(chunk, encoding, cb) {
       self._rotate();
       self.once('ready', function() {
         self.writer.size += line.length;
-        self.writer.write(line);
-        next();
+        self.writer.write(line, next);
       });
     } else {
       self.writer.size += line.length;
-      self.writer.write(line);
-      next();
+      self.writer.write(line, next);
     }
   }
 


### PR DESCRIPTION
I noticed that if you call logstream's `write` then immediately read the file being written to, there is a chance that the line being written won't make it to the file. I was able to fix this by moving the `next()` calls in logstream's `_write` into the underlying writer's write callback (see http://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback).

The problem can be reproduced with the following test:

```javascript
var path = require('path');
var fs = require('fs');
var temp = require('temp');

var LogStream = require('logrotate-stream');

temp.track();

for (var iteration = 0; iteration < 1000; iteration++) {
    var temp_dir = temp.mkdirSync('logstream-test');
    var file = path.join(temp_dir, 'rotate.log');

    var log_stream = new LogStream({
        file: file,
        size: '10m',
        keep: 1,
        compress: false
    });

    log_stream.on('finish', function () {
        var contents = fs.readFileSync(file, 'utf8');
        if (contents !== 'logged\n') {
            throw new Error('unexpected file contents: \'' + contents + '\'');
        }
    });

    log_stream.write('logged\n');
    log_stream.end();
}
```

This happens intermittently so it may take a few runs to reproduce.