### PR TITLE
Test with latest node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4.2"
+  - "node"


### PR DESCRIPTION
Added 0.12 (LTS), 4.2 (LTS) *node* which is an alias for stable (currently 5.5)
In my machine, tests pass on all versions.